### PR TITLE
FIX: Wrong atribute order in __getitem__ method

### DIFF
--- a/labfis/uncertainty.py
+++ b/labfis/uncertainty.py
@@ -179,7 +179,7 @@ class labfloat:
         return self._uncertainty
 
     def __getitem__(self, idx):
-        vals = (self.uncertainty, self.mean)
+        vals = (self.mean, self.uncertainty)
         return vals[idx]
 
     def __pos__(self):


### PR DESCRIPTION
Switched order of mean and uncertainty when unpacking or using list properties to access the labfloat attributes.